### PR TITLE
Adds configuration to be able to release to Maven Central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,15 @@
   <description>An OpenNLP based lemmatizer for (medical) texts written in German language</description>
   <url>https://github.com/mawiesne/DE-Lemma</url>
 
+  <licenses>
+    <license>
+      <name>Apache 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+      <comments>A business-friendly OSS license</comments>
+    </license>
+  </licenses>
+
   <organization>
     <name>Heilbronn University - Medical Informatics</name>
     <url>https://www.hs-heilbronn.de</url>
@@ -39,6 +48,9 @@
   <properties>
     <!-- Application settings -->
     <copyright.year>2023</copyright.year>
+    <license.inceptionYear>2023</license.inceptionYear>
+    <license.licenseName>apache_v2</license.licenseName>
+
     <java.source>17</java.source>
     <java.target>17</java.target>
 
@@ -66,6 +78,8 @@
     <junit.platform.version>1.9.1</junit.platform.version>
 
     <!-- additional plugin dependencies -->
+    <maven.license.plugin>2.3.0</maven.license.plugin>
+    <maven.gpg.plugin>3.1.0</maven.gpg.plugin>
     <maven.compiler.plugin>3.11.0</maven.compiler.plugin>
     <maven.javadoc.plugin>3.6.0</maven.javadoc.plugin>
     <maven.surefire.plugin>3.0.0</maven.surefire.plugin>
@@ -85,6 +99,19 @@
     <jacoco.version>0.8.8</jacoco.version>
 
   </properties>
+
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <name>Sonatype Nexus snapshot repository</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+    <repository>
+      <id>ossrh</id>
+      <name>Sonatype Nexus release repository</name>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+  </distributionManagement>
 
   <dependencyManagement>
     <dependencies>
@@ -223,6 +250,38 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>license-maven-plugin</artifactId>
+          <version>${maven.license.plugin}</version>
+          <configuration>
+            <verbose>false</verbose>
+            <includes>
+              <include>**/*.java</include>
+            </includes>
+          </configuration>
+          <executions>
+            <execution>
+              <id>generate-license-headers</id>
+              <goals>
+                <goal>update-file-header</goal>
+              </goals>
+              <phase>process-sources</phase>
+              <configuration>
+                <roots>
+                  <root>src/main/java</root>
+                  <root>src/test/java</root>
+                </roots>
+                <addJavaLicenseAfterPackage>false</addJavaLicenseAfterPackage>
+                <processStartTag>
+                  ========================LICENSE_START=================================
+                </processStartTag>
+                <processEndTag>=========================LICENSE_END==================================
+                </processEndTag>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>${maven.compiler.plugin}</version>
@@ -230,6 +289,20 @@
             <source>${java.source}</source>
             <target>${java.target}</target>
           </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>${maven.source.plugin}</version>
+          <executions>
+            <execution>
+              <id>attach-sources</id>
+              <phase>verify</phase>
+              <goals>
+                <goal>jar-no-fork</goal>
+              </goals>
+            </execution>
+          </executions>
         </plugin>
         <plugin>
           <artifactId>maven-javadoc-plugin</artifactId>
@@ -305,6 +378,20 @@
             <execution>
               <goals>
                 <goal>check</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-gpg-plugin</artifactId>
+          <version>${maven.gpg.plugin}</version>
+          <executions>
+            <execution>
+              <id>sign-artifacts</id>
+              <phase>verify</phase>
+              <goals>
+                <goal>sign</goal>
               </goals>
             </execution>
           </executions>
@@ -409,6 +496,33 @@
                 </goals>
               </execution>
             </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+          </plugin>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>license-maven-plugin</artifactId>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
# What does this PR do?

- Adds a `release`-profile to be able to conduct a release via OSS Sonatype
- Proposes ASLv2 as a license for this project 
  - Note: If `release` is enabled, the license maven plugin would take care of the related file header changes.
- Creating a Sonatype account + getting you access to publish under `de.hs-heilbronn.mi` to Maven Central can be done with a :coffee: in office ;-)